### PR TITLE
debian: replace make clean by dh_auto_clean

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -36,7 +36,7 @@ clean: unpatch
 	dh_testroot
 	rm -f build-stamp configure-stamp
 	# Add here commands to clean up after the build process.
-	$(MAKE) clean
+	dh_auto_clean
 	dh_clean 
 	rm -fr aclocal.m4 compile config.guess config.h config.h.in config.log config.status config.sub configure INSTALL install-sh libtool ltmain.sh m4 Makefile.in missing stamp-h1
 


### PR DESCRIPTION
"make clean" requires a Makefile to start with,
which does not exist before the autotools have been run the first time..
Instead, call dh_auto_clean, which will execute
make clean only when it finds a Makefile.
